### PR TITLE
fix: prevent DataAmount crash by guarding dataSize access

### DIFF
--- a/src/components/Dashboard/DataAmount.vue
+++ b/src/components/Dashboard/DataAmount.vue
@@ -1,12 +1,12 @@
 <template>
   <v-card outlined width="100%" height="100%" class="data-amount">
-    <div class="data-amount-container" v-if="dataSize">
+    <div class="data-amount-container" v-if="dataSize && dataSize.questions && dataSize.users !== undefined">
       <div class="user-amount details">
         <div class="icon-container">
           <v-icon size="30" color="#2F80ED">{{ mdiAccount }}</v-icon>
         </div>
         <div class="amount-info">
-          <span class="amount">{{ dataSize.users }}</span>
+          <span class="amount">{{ usersAmount }}</span>
           <span class="type">{{ $t('DASHBOARD.DATA_AMOUNT.users') }}</span>
         </div>
       </div>
@@ -17,7 +17,7 @@
           }}</v-icon>
         </div>
         <div class="amount-info">
-          <span class="amount">{{ dataSize.questions.general }}</span>
+          <span class="amount">{{ questionsAmount }}</span>
           <span class="type">{{ $t('TEST.QUIZ.questions') }}</span>
         </div>
       </div>
@@ -37,7 +37,7 @@
           }}</v-icon>
         </div>
         <div class="amount-info">
-          <span class="amount">{{ dataSize.tests }}</span>
+          <span class="amount">{{ testsAmount }}</span>
           <span class="type">{{ $t('TEST.QUIZ.quizzes') }}</span>
         </div>
       </div>
@@ -67,10 +67,35 @@ export default {
     dataSize() {
       return this.$store.getters.getDataSize;
     },
+
+    usersAmount() {
+      return this.dataSize && typeof this.dataSize.users === "number"
+        ? this.dataSize.users
+        : 0;
+    },
+
+    questionsAmount() {
+      return this.dataSize &&
+        this.dataSize.questions &&
+        typeof this.dataSize.questions.general === "number"
+        ? this.dataSize.questions.general
+        : 0;
+    },
+
+    testsAmount() {
+      return this.dataSize && typeof this.dataSize.tests === "number"
+        ? this.dataSize.tests
+        : 0;
+    },
+
     subjectsAmount() {
-      return this.$store.state.Subject.subjects.length;
+      return this.$store.state.Subject &&
+        this.$store.state.Subject.subjects
+        ? this.$store.state.Subject.subjects.length
+        : 0;
     }
   }
+
 };
 </script>
 


### PR DESCRIPTION
Fixed issue: #15 

### Summary

This PR fixes a dashboard crash caused by unsafe access to nested `dataSize`
properties in `DataAmount.vue` before Firestore data is fully loaded.

### Root Cause
`dataSize` is set asynchronously. During initial render, nested fields such
as `questions.general` may be undefined, leading to runtime errors.

### Changes
- Refactored `DataAmount.vue` to derive all values via computed properties
- Added safe default values for users, questions, tests, and subjects
- Removed unsupported optional chaining from Vue 2 templates

### Result
- Dashboard no longer crashes on initial load
- Component renders safely under slow network conditions
- Fully compatible with Vue 2 template compiler

Before:
<img width="2510" height="1165" alt="image" src="https://github.com/user-attachments/assets/79c94134-7e9a-4d79-8128-991e388a19c8" />


After:
<img width="2524" height="1303" alt="image" src="https://github.com/user-attachments/assets/04d2ba8d-16eb-4f48-b385-d406bd033264" />
