### PR TITLE
Fix Tests.vue crash when DataSize is not yet loaded

### DIFF
--- a/src/components/Tests/Tests.vue
+++ b/src/components/Tests/Tests.vue
@@ -220,6 +220,7 @@ import DeleteAlert from "./DeleteAlertTests";
 import SearchBox from "../Shared/SearchBox";
 import { getNowISOString } from "../../utils/date";
 import { analytics } from "../../main";
+import { watch } from "@vue/composition-api";
 
 export default {
   name: "Tests",
@@ -299,8 +300,13 @@ export default {
       return this.$store.getters.userInfo;
     },
     pageAmount() {
-      const testsAmount = this.$store.getters.getDataSize.tests;
-      return Math.ceil(testsAmount / this.itemsPerPage) || 1;
+      const dataSize = this.$store.getters.getDataSize;
+      const testsAmount = dataSize && typeof dataSize.tests === "number" ? dataSize.tests : 0;
+      return Math.max(1, Math.ceil(testsAmount / this.itemsPerPage));
+    },
+    hasDataSize() {
+      const ds = this.$store.getters.getDataSize;
+      return ds && typeof ds.tests === "number";
     }
   },
   methods: {
@@ -416,16 +422,28 @@ export default {
         user: this.userInfo,
         isSearching: this.isSearching
       });
+    },
+    loadFirstPage() {
+      this.$store.dispatch("loadFOLTestPage", {
+        page: 1,
+        itemsPerPage: this.itemsPerPage,
+        mode: "first"
+      });
+    }
+  },
+  watch: {
+    hasDataSize(ready) {
+      if (ready) {
+        this.loadFirstPage();
+      }
     }
   },
   mounted() {
     this.deleteConfirmed = false;
     this.$store.dispatch("checkDeleteMarkTests");
-    this.$store.dispatch("loadFOLTestPage", {
-      page: 1,
-      itemsPerPage: this.itemsPerPage,
-      mode: "first"
-    });
+    if(this.hasDataSize){
+      this.loadFirstPage();
+    }
   },
   beforeDestroy() {
     this.search = "";

--- a/src/components/Tests/Tests.vue
+++ b/src/components/Tests/Tests.vue
@@ -220,7 +220,6 @@ import DeleteAlert from "./DeleteAlertTests";
 import SearchBox from "../Shared/SearchBox";
 import { getNowISOString } from "../../utils/date";
 import { analytics } from "../../main";
-import { watch } from "@vue/composition-api";
 
 export default {
   name: "Tests",


### PR DESCRIPTION
Fixed issue: #17 

### PR Description

This PR fixes a runtime crash in `Tests.vue` caused by accessing
`getDataSize.tests` before the DataSize document is fully loaded from Firestore.

Previously, the component assumed `dataSize` was immediately available during
`mounted()`, which is not always true. This resulted in errors like:

```bash
TypeError: Cannot read properties of null (reading 'tests')
```

**Root cause**

- loadFOLTestPage and pagination logic depend on dataSize.tests
- mounted() was dispatching actions before dataSize finished loading
- Vue attempted to compute pageAmount and render pagination with null data

**Solution**

- Added a defensive pageAmount computed property that safely handles
- missing dataSize
- Introduced a reactive guard (hasDataSize) to ensure pagination logic
- runs only after DataSize is available
- Deferred the initial page load using a watcher instead of running it
- unconditionally in mounted()

**After fix**

- Tests page loads safely even when DataSize is delayed
- Pagination always renders with valid values
- No runtime errors during initial render or auto sign-in

Before:
<img width="2519" height="1237" alt="image" src="https://github.com/user-attachments/assets/eb1b695a-b6b4-41f5-9461-dc710474d75b" />

After:
<img width="2522" height="1328" alt="image" src="https://github.com/user-attachments/assets/6fc669b8-236c-4901-9295-2eea988f8254" />
