### PR TITLE
Fix Questions.vue crash when DataSize is not loaded

### DIFF
--- a/src/components/Questions/Questions.vue
+++ b/src/components/Questions/Questions.vue
@@ -315,13 +315,20 @@ export default {
       return this.$store.getters.userInfo;
     },
     pageAmount() {
-      const questionAmount = this.$store.getters.getDataSize.questions.general;
-      return Math.ceil(questionAmount / this.itemsPerPage) || 1;
+      const dataSize = this.$store.getters.getDataSize;
+      const questionAmount = dataSize && dataSize.questions && typeof dataSize.questions.general === 'number'
+        ? dataSize.questions.general
+        : 0;
+      return Math.max(1, Math.ceil(questionAmount / this.itemsPerPage));
     },
     getQuestionTests() {
       const titles = this.questionTests.map(t => "'" + t.title + "'");
       titles.sort((t1, t2) => (t1 > t2 ? 1 : -1));
       return titles.join(", ");
+    },
+    hasDataSize() {
+      const dataSize = this.$store.getters.getDataSize;
+      return !!(dataSize && dataSize.questions);
     }
   },
   watch: {
@@ -340,6 +347,15 @@ export default {
     },
     selectedSubject() {
       this.searchQuery(this.search);
+    },
+    hasDataSize(val) {
+      if (val) {
+        this.$store.dispatch("loadFOLQuestionPage", {
+          page: 1,
+          itemsPerPage: this.itemsPerPage,
+          mode: "first"
+        });
+      }
     }
   },
   methods: {
@@ -493,11 +509,6 @@ export default {
   mounted() {
     this.deleteConfirmed = false;
     this.$store.dispatch("checkDeleteMarkQuestions");
-    this.$store.dispatch("loadFOLQuestionPage", {
-      page: 1,
-      itemsPerPage: this.itemsPerPage,
-      mode: "first"
-    });
   },
   beforeDestroy() {
     this.search = "";

--- a/src/components/Questions/Questions.vue
+++ b/src/components/Questions/Questions.vue
@@ -141,7 +141,7 @@
           :length="
             !isSearching
               ? pageAmount
-              : Math.ceil(filteredQuestions.length / itemsPerPage)
+              : Math.max(1, Math.ceil(filteredQuestions.length / itemsPerPage))
           "
           @pageChange="
             !isSearching ? (page = $event.page) : (searchPage = $event.page);
@@ -316,19 +316,18 @@ export default {
     },
     pageAmount() {
       const dataSize = this.$store.getters.getDataSize;
-      const questionAmount = dataSize && dataSize.questions && typeof dataSize.questions.general === 'number'
-        ? dataSize.questions.general
-        : 0;
-      return Math.max(1, Math.ceil(questionAmount / this.itemsPerPage));
+      const total =
+        dataSize &&
+        dataSize.questions &&
+        typeof dataSize.questions.general === "number"
+          ? dataSize.questions.general
+          : 0;
+      return Math.max(1, Math.ceil(total / this.itemsPerPage));
     },
     getQuestionTests() {
       const titles = this.questionTests.map(t => "'" + t.title + "'");
       titles.sort((t1, t2) => (t1 > t2 ? 1 : -1));
       return titles.join(", ");
-    },
-    hasDataSize() {
-      const dataSize = this.$store.getters.getDataSize;
-      return !!(dataSize && dataSize.questions);
     }
   },
   watch: {
@@ -347,15 +346,6 @@ export default {
     },
     selectedSubject() {
       this.searchQuery(this.search);
-    },
-    hasDataSize(val) {
-      if (val) {
-        this.$store.dispatch("loadFOLQuestionPage", {
-          page: 1,
-          itemsPerPage: this.itemsPerPage,
-          mode: "first"
-        });
-      }
     }
   },
   methods: {
@@ -508,6 +498,20 @@ export default {
   },
   mounted() {
     this.deleteConfirmed = false;
+
+    this.search = "";
+    this.selectedSubject = null;
+    this.isSearching = false;
+    this.page = 1;
+    this.searchPage = 1;
+    this.$store.commit("resetFilteredQuestions");
+    this.$store.commit("resetCurrentQuestionsPage");
+    this.$store.dispatch("loadDataSize");
+    this.$store.dispatch("loadFOLQuestionPage", {
+      page: 1,
+      itemsPerPage: this.itemsPerPage,
+      mode: "first"
+    });
     this.$store.dispatch("checkDeleteMarkQuestions");
   },
   beforeDestroy() {


### PR DESCRIPTION
Fixed issue: #19 

### PR Summary

This PR fixes a runtime crash in `Questions.vue` caused by accessing
`getDataSize.questions.general` before the Firestore DataSize document
is fully loaded.

### Root cause

- `getDataSize` is loaded asynchronously
- Questions.vue accessed nested properties during render and `mounted()`
- This resulted in `TypeError: Cannot read properties of null`

### Solution

- Added defensive guards to the `pageAmount` computed property
- Introduced a `hasDataSize` reactive guard
- Deferred the initial page load using a watcher instead of `mounted()`

### Why this approach

- Prevents race conditions between Firestore and Vue lifecycle
- Matches existing fixes applied to Tests.vue and DataAmount.vue
- Keeps store logic unchanged
- Fully compatible with Vue 2 and Vuex

### Affected files

- `src/components/Questions/Questions.vue`

### Result

- Questions page no longer crashes on initial load
- Pagination renders correctly
- Page data loads only when DataSize is ready

Before:
<img width="2524" height="1236" alt="image" src="https://github.com/user-attachments/assets/2ba8fbf0-87c7-4bf9-9b63-76ec24b1c4f9" />

After:
<img width="2531" height="1321" alt="image" src="https://github.com/user-attachments/assets/c6b4dff8-2df3-4c2f-95f8-26ee75e6bb97" />


### Fixed another issue : 

**Problem**:

- it shows no questions even if you have questions---it only shows when you filter it 

<img width="1162" height="722" alt="image" src="https://github.com/user-attachments/assets/74f0c66b-6af8-4627-b55b-1889642889a0" />


**after changes**:

- the question page will show all the questions it has..and the filter works fine as before

<img width="1894" height="890" alt="image" src="https://github.com/user-attachments/assets/152dd827-58e8-433e-891c-8c6c35a02419" />
