### PR TITLE
Fix Inbox render crash when question-requests size is null

### DIFF
--- a/src/components/Requests/Inbox.vue
+++ b/src/components/Requests/Inbox.vue
@@ -243,13 +243,17 @@ export default {
       return itHas;
     },
     pageAmount() {
-      const requestAmount = this.$store.getters.getDataSize[
-        "question-requests"
-      ];
+      const dataSize = this.$store.getters.getDataSize;
+      if(!dataSize || !dataSize["question-requests"]){
+        return 1;
+      }
+      const requestAmount = dataSize["question-requests"];
       const amount =
         this.userClaims && this.userClaims["admin"]
-          ? requestAmount.general
-          : requestAmount.users[this.userInfo.id];
+          ? requestAmount.general || 0
+          : (requestAmount.users &&
+              requestAmount.users[this.userInfo?.id]) ||
+            0;
       return Math.ceil(amount / this.itemsPerPage) || 1;
     },
     getQuestionTests() {


### PR DESCRIPTION
Fixed issue: #21 

### PR summary

Inbox.vue was crashing during initial render because the
pageAmount computed property accessed
getDataSize["question-requests"] before Firestore data
was loaded.

This PR adds defensive guards in Inbox.vue pagination
logic, preventing render-time crashes and keeping
pagination stable for both admin and non-admin users.

there is another error from request.store.js file which is handled in this pr #12 

Before:
<img width="2509" height="1290" alt="image" src="https://github.com/user-attachments/assets/12325f8f-dd1b-47c3-8236-4891ce90ab78" />

After:
<img width="2518" height="1311" alt="image" src="https://github.com/user-attachments/assets/cae933e9-2b77-4a61-a8ea-7325356fc9aa" />
