### PR TITLE
Fix TestForm render crash and save button validation

### DIFF
--- a/src/components/Tests/TestForm.vue
+++ b/src/components/Tests/TestForm.vue
@@ -23,13 +23,12 @@
             class="mr-4"
             :loading="loading"
             :disabled="
-              randomQuestionsNumber < 1 ||
+              !title ||
+              (testType === 'selected' && !selectedQuestions.length) ||
+              (testType === 'random' &&
+                (randomQuestionsNumber < 1 ||
                 randomQuestionsNumber > checkNumber ||
-                !title ||
-                (testType !== 'auto' &&
-                  (testType === 'selected'
-                    ? !selectedQuestions.length
-                    : !selectedRandom.length))
+                !selectedRandom.length))
             "
             :dark="
               randomQuestionsNumber > 0 &&
@@ -566,7 +565,8 @@ export default {
       return amount;
     },
     pageAmount() {
-      const questionAmount = this.$store.getters.getDataSize.questions.general;
+      const dataSize = this.$store.getters.getDataSize;
+      const questionAmount = dataSize?.questions?.general ?? 0;
       return Math.ceil(questionAmount / this.itemsPerPage) || 1;
     },
     selectedAllSubjects() {


### PR DESCRIPTION
This PR fixes two issues in TestForm.vue:

• Prevents a render-time crash caused by accessing
  getDataSize.questions.general before Firestore data-size finishes loading
  by adding a null-safe guard in the pageAmount computed property.

• Fixes the Save button validation logic so that random-quiz constraints
  are only applied to the "random" quiz type. This allows the Save button
  to correctly enable for "selected" quizzes after valid question selection.

Before:
<img width="2521" height="1312" alt="image" src="https://github.com/user-attachments/assets/9877c204-5d8d-4a7d-8baf-071b257d53b1" />


After:
<img width="2528" height="1307" alt="image" src="https://github.com/user-attachments/assets/3f81347d-1d31-49b6-924b-c954d5506624" />


No logic or UX behavior is changed beyond preventing crashes and ensuring
correct validation behavior.
