### PR TITLE
Fix date formatting and i18n month warnings in BackupsTable

### DIFF
--- a/src/components/Admin/BackupsTable.vue
+++ b/src/components/Admin/BackupsTable.vue
@@ -259,7 +259,7 @@ export default {
       mdiCloudUpload,
       deleteBackupSnackBar: false,
       deleteItem: null,
-      months: null,
+      months: {},
       headers: [
         {
           text: "id",
@@ -313,22 +313,33 @@ export default {
         : this.currentMonth - 2;
     },
     pastMonths() {
+      const m1 = this.months[this.lastMonth];
+      const m2 = this.months[this.twoMonthsAgo];
       return [
-        this.$t("SHARED.DATE.MONTH." + this.months[this.lastMonth]),
-        this.$t("SHARED.DATE.MONTH." + this.months[this.twoMonthsAgo])
+        m1 ? this.$t("SHARED.DATE.MONTH." + m1) : "",
+        m2 ? this.$t("SHARED.DATE.MONTH." + m2) : ""
       ];
     }
   },
   methods: {
     formatDate(date) {
-      const month = new Date(date).getMonth() + 1;
+      if (!date) {
+        return this.$t("SHARED.DATE.in_progress") || "—";
+      }
+      const d = new Date(date);
+      if (isNaN(d.getTime())) {
+        return "—";
+      }
+      const monthIndex = d.getMonth() + 1;
+      const monthKey = this.months[monthIndex];
 
-      const dateTime = new Date(date).toString();
-      const sub = dateTime.substr(7, 17);
+      if (!monthKey) {
+        return d.toDateString();
+      }
       const monthName = this.$t(
-        "SHARED.DATE.MONTH." + this.months[month]
+        "SHARED.DATE.MONTH." + monthKey
       ).substr(0, 3);
-
+      const sub = d.toString().substr(7, 17);
       return monthName + sub;
     },
     getBackupsByMonth(month) {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -280,6 +280,7 @@
     "DATE": {
       "today_at": "Today at",
       "yesterday_at": "Yesterday at",
+      "in_progress": "In progress",
       "WEEKDAY": {
         "sunday": "Sunday",
         "monday": "Monday",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -280,6 +280,7 @@
     "DATE": {
       "today_at": "Hoy a las",
       "yesterday_at": "Ayer a las",
+      "in_progress": "En progreso",
       "WEEKDAY": {
         "sunday": "Domingo",
         "monday": "Lunes",

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -280,6 +280,7 @@
     "DATE": {
       "today_at": "Hoje às",
       "yesterday_at": "Ontem às",
+      "in_progress": "Em andamento",
       "WEEKDAY": {
         "sunday": "Domingo",
         "monday": "Segunda-feira",


### PR DESCRIPTION
Fixed issue: #25 

### PR Summary

This PR fixes multiple date-related issues in the Backups table.

### What was fixed
- Prevents `SHARED.DATE.MONTH.undefined` vue-i18n warnings by safely resolving month keys.
- Handles missing or invalid `end` dates gracefully (e.g. backups still in progress).
- Initializes `months` defensively to avoid access before store hydration.

### Changes made
- Added guards before calling `$t("SHARED.DATE.MONTH.*")`.
- Improved `formatDate()` to handle null/invalid date values.
- UX improvement: replaces "SHA date" with a safe placeholder for ongoing backups.
- added key value for `in progress` in all the languages 

Before:
<img width="2469" height="1106" alt="image" src="https://github.com/user-attachments/assets/aa657c7e-4425-4777-9860-6b4bc9c51758" />

After:
<img width="2450" height="1127" alt="image" src="https://github.com/user-attachments/assets/67b0b523-c7ea-4a65-a8c8-393d42821448" />

